### PR TITLE
Fix bugFix/issue57 - mongoDB UTC 조회에 맞춰 조회 시간 재수정

### DIFF
--- a/src/main/java/com/lion/codecatcherbe/domain/coding/service/CodingService.java
+++ b/src/main/java/com/lion/codecatcherbe/domain/coding/service/CodingService.java
@@ -134,8 +134,8 @@ public class CodingService {
 
     public ResponseEntity<QuestionListRes> findProblemList(String token) {
         // 오늘 날짜를 가져오고 끝날짜를 24시간 뒤로 설정하여 문제의 정보를 가지고 옴
-        LocalDateTime start = LocalDateTime.now().truncatedTo(ChronoUnit.DAYS);
-        List<Problem> problemList = findProblemsByCreatedAt(start.plusHours(9L), start.plusDays(1L).plusHours(9L).minusSeconds(1L));
+        LocalDateTime start = LocalDateTime.now().plusHours(9L).truncatedTo(ChronoUnit.DAYS);
+        List<Problem> problemList = findProblemsByCreatedAt(start, start.plusDays(1L).minusSeconds(1L));
 
         // 레벨 순으로 정렬
         problemList.sort(Comparator.comparingLong(Problem::getLevel));

--- a/src/main/java/com/lion/codecatcherbe/domain/mypage/MyPageService.java
+++ b/src/main/java/com/lion/codecatcherbe/domain/mypage/MyPageService.java
@@ -81,10 +81,10 @@ public class MyPageService {
         List<BookmarkInfo> bookmarkDetails = findTop4RecentBookmarkDetails(userId);
 
         // 지난 테스트 문제 최근 4개 리스트 가져오기
-        List<ProblemInfo> problemDetails = findTop4RecentProblemDetails(user.getCreatedAt().truncatedTo(ChronoUnit.DAYS).plusHours(9L), userId);
+        List<ProblemInfo> problemDetails = findTop4RecentProblemDetails(user.getCreatedAt().truncatedTo(ChronoUnit.DAYS), userId);
 
         // 해당 년,월 월간 달성률 리스트 가져오기
-        List<Achievement> achievementList = findAchievementList(userId, LocalDateTime.now().getYear(), LocalDateTime.now().getMonthValue());
+        List<Achievement> achievementList = findAchievementList(userId, LocalDateTime.now().plusHours(9L).getYear(), LocalDateTime.now().plusHours(9L).getMonthValue());
 
         MyPageInfoRes myPageInfoRes = MyPageInfoRes.builder()
             .bookmarkInfo(bookmarkDetails)
@@ -96,8 +96,8 @@ public class MyPageService {
     }
 
     private List<Achievement> findAchievementList(String userId, int year, int month) {
-        LocalDateTime start = LocalDate.of(year, month, 1).atStartOfDay().plusHours(9L);
-        LocalDateTime end = LocalDate.of(year, month, 1).plusMonths(1).atStartOfDay().plusHours(9L).minusSeconds(1L);
+        LocalDateTime start = LocalDate.of(year, month, 1).atStartOfDay();
+        LocalDateTime end = LocalDate.of(year, month, 1).plusMonths(1).atStartOfDay().minusSeconds(1L);
 
         MatchOperation matchOperation = Aggregation.match(Criteria
             .where("createdAt").gte(start).lt(end)
@@ -114,8 +114,8 @@ public class MyPageService {
 
     private List<ProblemInfo> findTop4RecentProblemDetails(LocalDateTime signedAt, String userId) {
         // 유저의 createdAt 을 고려해서 하루 전 기준으로 4개를 가지고 와야함
-        LocalDateTime start = LocalDateTime.now().truncatedTo(ChronoUnit.DAYS).minusDays(30).plusHours((9L));
-        LocalDateTime end = LocalDateTime.now().truncatedTo(ChronoUnit.DAYS).plusHours(9L).minusSeconds(1);
+        LocalDateTime start = LocalDateTime.now().plusHours(9L).truncatedTo(ChronoUnit.DAYS).minusDays(30);
+        LocalDateTime end = LocalDateTime.now().plusHours(9L).truncatedTo(ChronoUnit.DAYS).minusSeconds(1);
 
         // 가입일이 한달 전일 경우 조회 범위 조정
         if (signedAt.isAfter(start)) start = signedAt;
@@ -291,7 +291,7 @@ public class MyPageService {
     }
 
     private List<ProblemMoreInfo> findMoreProblemDetails(String userId, Pageable pageable) {
-        LocalDateTime end = LocalDateTime.now().truncatedTo(ChronoUnit.DAYS).plusHours(9L).minusSeconds(1);
+        LocalDateTime end = LocalDateTime.now().plusHours(9L).truncatedTo(ChronoUnit.DAYS).minusSeconds(1);
         MatchOperation matchOperation = Aggregation.match(Criteria.where("createdAt").lte(end));
         LookupOperationWithPipeline lookupOperation = new LookupOperationWithPipeline("submit", "_id", "submits", userId);
         UnwindOperation unwindOperation = Aggregation.unwind("submits", true);

--- a/src/main/java/com/lion/codecatcherbe/domain/score/ScoreService.java
+++ b/src/main/java/com/lion/codecatcherbe/domain/score/ScoreService.java
@@ -151,7 +151,7 @@ public class ScoreService {
         ScoreSubmitResultRes scoreSubmitResultRes = getScoreSubmitResult(scoreProblemReq);
 
         // (2) 제출을 하긴 했으므로 달성률 객체 생성 or 가져오기
-        LocalDateTime start = LocalDateTime.now().truncatedTo(ChronoUnit.DAYS).plusHours(9L);
+        LocalDateTime start = LocalDateTime.now().plusHours(9L).truncatedTo(ChronoUnit.DAYS);
         LocalDateTime end = start.plusHours(24L).minusSeconds(1L);
         Achieve achieve = achieveRepository.findByUserIdAndCreatedAtBetween(userId, start, end).orElse(null);
 


### PR DESCRIPTION
#57 
- CodingService : 오늘 3문제 가져오기
- MyPageService : 최근 4문제 가져오기 / 월간 달성률 가져오기 / 문제 더보기
- ScoreService : 달성률 갱신

서버 시간이 UTC 이므로 한국시간을 기준으로 저장할 때는 MongoDB 에 들어갈시 서버 시간에 맞춰질 것을 생각해 +9h 를 한 후 저장 해주어야하지만, 조회 시에는 지정한 시간을 시간 차 인식없이 조회 하므로 +9h 를 먼저 해주고 Day로 컷하여 조회한다.