### PR TITLE
내 코드에 대한 GPT 리뷰를 하루에 한번만 실행 가능하도록 

### DIFF
--- a/src/main/java/com/lion/codecatcherbe/CodeCatcherBeApplication.java
+++ b/src/main/java/com/lion/codecatcherbe/CodeCatcherBeApplication.java
@@ -2,8 +2,10 @@ package com.lion.codecatcherbe;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
+@EnableScheduling
 public class CodeCatcherBeApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/com/lion/codecatcherbe/domain/user/model/User.java
+++ b/src/main/java/com/lion/codecatcherbe/domain/user/model/User.java
@@ -22,9 +22,10 @@ public class User {
     private LocalDateTime createdAt = LocalDateTime.now().plusHours(9L);
     @Default
     private int level = 1;
-
     @Default
     private int exp = 0;
+    @Default
+    private boolean isUsed = false;
 
     public void setUserName (String newName) {
         this.name = newName;
@@ -33,5 +34,9 @@ public class User {
     public void setLevAndExp (int level, int exp) {
         this.level = level;
         this.exp = exp;
+    }
+
+    public void toggleIsUsed() {
+        this.isUsed = true;
     }
 }

--- a/src/main/java/com/lion/codecatcherbe/infra/gpt/GPTController.java
+++ b/src/main/java/com/lion/codecatcherbe/infra/gpt/GPTController.java
@@ -8,6 +8,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -30,9 +31,9 @@ public class GPTController {
         ChatGPT 내 코드 피드백
     */
     @PostMapping("/feedback")
-    public ResponseEntity<GPTReviewRes> gptFeedbackTest (@RequestBody CodeReviewReq codeReviewReq) {
+    public ResponseEntity<GPTReviewRes> gptFeedbackTest (@RequestHeader(value = "Authorization", required = false) String token, @RequestBody CodeReviewReq codeReviewReq) {
 
-        return gptService.getGptFeedback(codeReviewReq);
+        return gptService.getGptFeedback(token, codeReviewReq);
     }
 
     /*

--- a/src/main/java/com/lion/codecatcherbe/infra/gpt/GPTService.java
+++ b/src/main/java/com/lion/codecatcherbe/infra/gpt/GPTService.java
@@ -5,6 +5,7 @@ import com.lion.codecatcherbe.domain.coding.dto.response.ProblemGenRes;
 import com.lion.codecatcherbe.domain.coding.model.Problem;
 import com.lion.codecatcherbe.domain.coding.repository.ProblemRepository;
 import com.lion.codecatcherbe.domain.coding.service.SequenceGeneratorService;
+import com.lion.codecatcherbe.domain.user.UserService;
 import com.lion.codecatcherbe.infra.gpt.dto.request.CodeReviewReq;
 import com.lion.codecatcherbe.infra.gpt.dto.response.GPTReviewRes;
 import com.lion.codecatcherbe.infra.gpt.prompt.ReviewPrompt;
@@ -26,9 +27,10 @@ import org.springframework.stereotype.Service;
 public class GPTService {
 
     private final SequenceGeneratorService sequenceGeneratorService;
+    private final UserService userService;
     private final ProblemRepository problemRepository;
     private final AiClient client;
-    public ResponseEntity<GPTReviewRes> getGptFeedback(CodeReviewReq codeReviewReq) {
+    public ResponseEntity<GPTReviewRes> getGptFeedback(String token, CodeReviewReq codeReviewReq) {
         String myCode = codeReviewReq.getMyCode();
         Long problemId = codeReviewReq.getProblemId();
 
@@ -65,6 +67,8 @@ public class GPTService {
         Gson gson = new Gson();
 
         GPTReviewRes gptReviewRes = gson.fromJson(jsonString, GPTReviewRes.class);
+
+        userService.isUsedToTrue(token);
 
         // 객체 반환
         return new ResponseEntity<>(gptReviewRes, HttpStatus.OK);


### PR DESCRIPTION
#66 
- Application에 @EnableScheduling 추가
- GPTController 의 POST /gpt/feedback 에 토큰 파라미터 추가
- - UserService 에 user 의 isUsed 상태를 True 로 변환하는 함수와 정각에 모든 유저의 isUsed 상태를 False 로 변환하는 함수 구현
- User Document 에 GPT 내코드 리뷰를 사용 상태를 확인할 수 있는 isUsed 컬럼 추가
- getGptFeedback() 함수에 유저의 GPT 사용 상태 변환 로직 추가