### PR TITLE
(#72) BugFix 코딩테스트/issue78 : (문제 저장) POST /coding/gen

### DIFF
--- a/src/main/java/com/lion/codecatcherbe/domain/coding/service/CodingService.java
+++ b/src/main/java/com/lion/codecatcherbe/domain/coding/service/CodingService.java
@@ -249,7 +249,7 @@ public class CodingService {
             .python_explain(problemGenRes.getPython_explain())
             .java_explain(problemGenRes.getJava_explain())
             .js_code(problemGenRes.getJs_code())
-            .js_explain(problemGenRes.getJava_explain())
+            .js_explain(problemGenRes.getJs_explain())
             .build();
 
         p.setCreatedAt(LocalDateTime.now().plusHours(9L));


### PR DESCRIPTION
related : #81 
- Problem 객체 Builder 로직에서 js_explain 인 java_explain 값으로 저장되는 오류 해결